### PR TITLE
Fix asciidoc warnings + typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@
 
 This extension allow usage of the _HiveMQ MQTT Client_ inside a Quarkus App, in JVM and Native mode.
 
-Added with the [SmallRye Reactive Messaging MQTT][https://smallrye.io/smallrye-reactive-messaging/4.3.0/mqtt/mqtt/]  allows usage of a new connector type **smallrye-mqtt-hivemq** that will use _HiveMQ MQTT Client_ instead of Vertx MQTT client.
+Added with the [SmallRye Reactive Messaging MQTT](https://smallrye.io/smallrye-reactive-messaging/4.3.0/mqtt/mqtt/) allows usage of a new connector type **smallrye-mqtt-hivemq** that will use _HiveMQ MQTT Client_ instead of Vertx MQTT client.
 
-This add some benefits to the original SmallRye MQTT:
+This adds some benefits to the original SmallRye MQTT:
 
 * Battle tested MQTT Client outside of Vertx landscape.
 * Management of external CA file for secure connections with self-signed certificates
 * Backpressure support integrated with MQTT QOS.
 * Automatic and configurable reconnect handling and message redelivery.
-* Real Health Check againsts a configurable topic (defaults to the standard MQTT $SYS/broker/uptime) integrated in Quarkus HealthReport.
-* Many others you can read in official documentation [here][https://hivemq.github.io/hivemq-mqtt-client/].
+* Real Health Check against a configurable topic (defaults to the standard MQTT $SYS/broker/uptime) integrated in Quarkus HealthReport.
+* Many others you can read in official documentation [here](https://hivemq.github.io/hivemq-mqtt-client/).
 
-For more informations about installation and configuration please read the documentation
-[here][https://quarkiverse.github.io/quarkiverse-docs/quarkus-hivemq-client/dev/index.html].
+For more information about installation and configuration please read the documentation
+[here](https://quarkiverse.github.io/quarkiverse-docs/quarkus-hivemq-client/dev/index.html).
 
 ## Contributors ✨
 

--- a/docs/modules/ROOT/pages/config.adoc
+++ b/docs/modules/ROOT/pages/config.adoc
@@ -88,3 +88,4 @@ Timeout to declare the MQTT Client not alive.
 --|int
 |`120000`
 | INCOMING_AND_OUTGOING
+|===

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -11,7 +11,7 @@ This adds some benefits to the original SmallRye MQTT:
 * Management of external CA file for secure connections with self-signed certificates
 * Backpressure support integrated with MQTT QOS
 * Automatic and configurable reconnection handling and message redelivery
-* Real Health Check againsts a configurable topic (defaults to the standard MQTT $SYS/broker/uptime) integrated in Quarkus HealthReport
+* Real Health Check against a configurable topic (defaults to the standard MQTT $SYS/broker/uptime) integrated in Quarkus HealthReport
 * Many others you can read in official documentation https://hivemq.github.io/hivemq-mqtt-client/[here].
 
 == Installation
@@ -31,10 +31,10 @@ If you also want to use SmallRye Reactive Messaging integration in your `pom.xml
 
 [source,xml]
 ----
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-smallrye-reactive-messaging-mqtt</artifactId>
-    </dependency>
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-smallrye-reactive-messaging-mqtt</artifactId>
+</dependency>
 ----
 
 
@@ -45,14 +45,14 @@ These are the configurations added to the original *SmallRye's MQTT Connector* o
 
 [source,xml]
 ----
-    <dependency>
-        <groupId>io.quarkiverse.hivemqclient</groupId>
-        <artifactId>quarkus-hivemq-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-smallrye-reactive-messaging-mqtt</artifactId>
-    </dependency>
+<dependency>
+    <groupId>io.quarkiverse.hivemqclient</groupId>
+    <artifactId>quarkus-hivemq-client</artifactId>
+</dependency>
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-smallrye-reactive-messaging-mqtt</artifactId>
+</dependency>
 ----
 
 


### PR DESCRIPTION
This PR closed unterminated table block. Also, there were a few typos in README.md and index.adoc.

Proof of all warnings gone:
<img width="575" alt="image" src="https://github.com/quarkiverse/quarkus-hivemq-client/assets/11942401/c8fa9999-0c53-461b-86c7-8fb363df24ae">

Proof of warnings before this PR:
<img width="810" alt="image" src="https://github.com/quarkiverse/quarkus-hivemq-client/assets/11942401/3a169ccc-8284-4a8f-877b-f7a617354f09">
