### PR TITLE
Add support to Native compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,33 +74,33 @@ jobs:
       run: tar -xzf maven-repo.tgz -C ~
     - name: Build with Maven
       run: mvn -V -B -am clean verify
-#  TODO there is an error under investigation on Native mode
-#  linux-build-native:
-#    name: PR - Linux - Native build - Latest Version
-#    runs-on: ubuntu-latest
-#    timeout-minutes: 60
-#    needs: validate-format
-#    strategy:
-#      matrix:
-#        java: [ 11 ]
-#    steps:
-#    - uses: actions/checkout@v4
-#    - name: Install JDK {{ matrix.java }}
-#      # Uses sha for added security since tags can be updated
-#      uses: actions/setup-java@v3
-#      with:
-#        distribution: 'temurin'
-#        java-version: ${{ matrix.java }}
-#        check-latest: true
-#        cache: 'maven'
-#    - name: Download Maven Repo
-#      uses: actions/download-artifact@v3
-#      with:
-#        name: maven-repo
-#        path: .
-#    - name: Extract Maven Repo
-#      shell: bash
-#      run: tar -xzf maven-repo.tgz -C ~
-#    - name: Build with Maven
-#      run: mvn -V -B -am clean verify -Dnative
+  linux-build-native:
+    name: PR - Linux - Native build - Latest Version
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: validate-format
+    strategy:
+      matrix:
+        java: [ 11, 17 ]
+        image: [ "ubi-quarkus-native-image:22.3-java17", "ubi-quarkus-mandrel:22.3-java17", "ubi-quarkus-graalvmce-builder-image:22.3-java17" ]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install JDK {{ matrix.java }}
+      # Uses sha for added security since tags can be updated
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: ${{ matrix.java }}
+        check-latest: true
+        cache: 'maven'
+    - name: Download Maven Repo
+      uses: actions/download-artifact@v3
+      with:
+        name: maven-repo
+        path: .
+    - name: Extract Maven Repo
+      shell: bash
+      run: tar -xzf maven-repo.tgz -C ~
+    - name: Build with Maven
+      run: mvn -V -B -am clean verify -Dnative -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }}
 

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -55,3 +55,32 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Build with Maven
         run: mvn -V -B -am clean verify
+  linux-build-native:
+    name: PR - Linux - Native build - Latest Version
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: validate-format
+    strategy:
+      matrix:
+        java: [ 11, 17 ]
+        image: [ "ubi-quarkus-native-image:22.3-java17", "ubi-quarkus-mandrel:22.3-java17", "ubi-quarkus-graalvmce-builder-image:22.3-java17" ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install JDK {{ matrix.java }}
+        # Uses sha for added security since tags can be updated
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          check-latest: true
+          cache: 'maven'
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v3
+        with:
+          name: maven-repo
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzf maven-repo.tgz -C ~
+      - name: Build with Maven
+        run: mvn -V -B -am clean verify -Dnative -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }}

--- a/pom.xml
+++ b/pom.xml
@@ -29,15 +29,14 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <smallrye-reactive-messaging-mqtt.version>4.10.1</smallrye-reactive-messaging-mqtt.version>
-    <microprofile-reactive-streams.version>3.0</microprofile-reactive-streams.version>
-    <microprofile-metrics-api.version>5.0.1</microprofile-metrics-api.version>
+    <smallrye-reactive-messaging-mqtt.version>3.22.1</smallrye-reactive-messaging-mqtt.version>
+    <microprofile-reactive-streams.version>1.0.1</microprofile-reactive-streams.version>
+    <microprofile-metrics-api.version>3.0.1</microprofile-metrics-api.version>
     <impsort-maven-plugin.version>1.9.0</impsort-maven-plugin.version>
     <formatter-maven-plugin.version>2.23.0</formatter-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.3.0</maven-checkstyle-plugin.version>
     <src.format.goal>format</src.format.goal>
     <src.sort.goal>sort</src.sort.goal>
-    <mutiny-rxjava.version>1.9.0</mutiny-rxjava.version>
     <hivemq.client.version>1.3.3</hivemq.client.version>
     <checkstyle.version>10.12.4</checkstyle.version>
     <quarkus.version>2.16.10.Final</quarkus.version>
@@ -137,6 +136,12 @@
     </plugins>
   </build>
   <profiles>
+    <profile>
+      <id>native</id>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+      </properties>
+    </profile>
     <profile>
       <id>it</id>
       <activation>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -16,14 +16,13 @@
       <version>${hivemq.client.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.smallrye.reactive</groupId>
-      <artifactId>smallrye-reactive-messaging-mqtt</artifactId>
-      <version>${smallrye-reactive-messaging-mqtt.version}</version>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <classifier>linux-x86_64</classifier>
     </dependency>
     <dependency>
       <groupId>io.smallrye.reactive</groupId>
-      <artifactId>mutiny</artifactId>
-      <version>${mutiny-rxjava.version}</version>
+      <artifactId>smallrye-reactive-messaging-mqtt</artifactId>
     </dependency>
     <dependency>
       <groupId>io.smallrye.reactive</groupId>
@@ -32,7 +31,6 @@
     <dependency>
       <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>
       <artifactId>microprofile-reactive-streams-operators-api</artifactId>
-      <version>${microprofile-reactive-streams.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.metrics</groupId>


### PR DESCRIPTION
close #105 

covered items:
- The following docker images are covered:
    - ubi-quarkus-native-image:22.3-java17
    - ubi-quarkus-mandrel:22.3-java17
    - ubi-quarkus-graalvmce-builder-image:22.3-java17
- End-to-end coverage
- GitHub action coverage
- ~~Documentation~~ (I prefer to cover this point on this Ticket: https://github.com/quarkiverse/quarkus-hivemq-client/issues/104)

How to test it locally: `mvn clean install -Dnative`

------------
Additional Changes:

We have downgraded the following deps `smallrye-reactive-messaging-mqtt.version`, `microprofile-reactive-streams.version` in order to be align with [Quarkus 2.16 BOM](https://github.com/quarkusio/quarkus/blob/2.16/bom/application/pom.xml). 

