### PR TITLE
Add support to DevServices

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -20,6 +20,20 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-devservices-deployment</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5-internal</artifactId>
       <scope>test</scope>
     </dependency>

--- a/deployment/src/main/java/io/quarkiverse/hivemqclient/deployment/MqttBuildTimeConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/hivemqclient/deployment/MqttBuildTimeConfig.java
@@ -1,0 +1,15 @@
+package io.quarkiverse.hivemqclient.deployment;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "mqtt", phase = ConfigPhase.BUILD_TIME)
+public class MqttBuildTimeConfig {
+
+    /**
+     * Configuration for DevServices. DevServices allows Quarkus to automatically start a MQTT broker in dev and test mode.
+     */
+    @ConfigItem
+    public MqttDevServicesBuildTimeConfig devservices;
+}

--- a/deployment/src/main/java/io/quarkiverse/hivemqclient/deployment/MqttDevServicesBuildTimeConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/hivemqclient/deployment/MqttDevServicesBuildTimeConfig.java
@@ -1,0 +1,69 @@
+package io.quarkiverse.hivemqclient.deployment;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class MqttDevServicesBuildTimeConfig {
+    /**
+     * If Dev Services for MQTT has been explicitly enabled or disabled. Dev Services are generally enabled
+     * by default, unless there is an existing configuration present. For MQTT, Dev Services starts a broker unless
+     * {@code *.host} or {@code *.port} are set for one of the connectors or if all the Reactive Messaging MQTT channel are
+     * configured
+     * with
+     * {@code host} or {@code port}.
+     */
+    @ConfigItem
+    public Optional<Boolean> enabled = Optional.empty();
+
+    /**
+     * Optional fixed port the dev service will listen to.
+     * <p>
+     * If not defined, the port will be chosen randomly.
+     */
+    @ConfigItem
+    public OptionalInt port;
+
+    /**
+     * The image to use.
+     */
+    @ConfigItem(defaultValue = "hivemq/hivemq-ce:2023.9")
+    public String imageName;
+
+    /**
+     * Indicates if the MQTT broker managed by Quarkus Dev Services is shared.
+     * When shared, Quarkus looks for running containers using label-based service discovery.
+     * If a matching container is found, it is used, and so a second one is not started.
+     * Otherwise, Dev Services for MQTT starts a new container.
+     * <p>
+     * The discovery uses the {@code quarkus-dev-service-mqtt} label.
+     * The value is configured using the {@code service-name} property.
+     * <p>
+     * Container sharing is only used in dev mode.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean shared;
+
+    /**
+     * The value of the {@code quarkus-dev-service-mqtt} label attached to the started container.
+     * This property is used when {@code shared} is set to {@code true}.
+     * In this case, before starting a container, Dev Services for MQTT looks for a container with the
+     * {@code quarkus-dev-service-mqtt} label
+     * set to the configured value. If found, it will use this container instead of starting a new one. Otherwise, it
+     * starts a new container with the {@code quarkus-dev-service-mqtt} label set to the specified value.
+     * <p>
+     * This property is used when you need multiple shared MQTT brokers.
+     */
+    @ConfigItem(defaultValue = "mqtt")
+    public String serviceName;
+
+    /**
+     * Environment variables that are passed to the container.
+     */
+    @ConfigItem
+    public Map<String, String> containerEnv;
+}

--- a/deployment/src/main/java/io/quarkiverse/hivemqclient/deployment/MqttDevServicesProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/hivemqclient/deployment/MqttDevServicesProcessor.java
@@ -1,0 +1,296 @@
+package io.quarkiverse.hivemqclient.deployment;
+
+import java.io.Closeable;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.utility.DockerImageName;
+
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.deployment.Feature;
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem.RunningDevService;
+import io.quarkus.deployment.builditem.DockerStatusBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
+import io.quarkus.deployment.console.StartupLogCompressor;
+import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
+import io.quarkus.deployment.logging.LoggingSetupBuildItem;
+import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.runtime.LaunchMode;
+import io.quarkus.runtime.configuration.ConfigUtils;
+
+/**
+ * Starts a HiveMQ broker as dev service if needed.
+ */
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
+public class MqttDevServicesProcessor {
+
+    private static final Logger log = Logger.getLogger(MqttDevServicesProcessor.class);
+
+    /**
+     * Label to add to shared Dev Service for MQTT running in containers.
+     * This allows other applications to discover the running service and use it instead of starting a new instance.
+     */
+    private static final String DEV_SERVICE_LABEL = "quarkus-dev-service-mqtt";
+
+    private static final int MQTT_PORT = 1883;
+
+    private static final ContainerLocator mqttContainerLocator = new ContainerLocator(DEV_SERVICE_LABEL, MQTT_PORT);
+    static volatile RunningDevService devService;
+    static volatile MqttDevServiceCfg cfg;
+    static volatile boolean first = true;
+
+    @BuildStep
+    public DevServicesResultBuildItem startMqttDevService(
+            DockerStatusBuildItem dockerStatusBuildItem,
+            LaunchModeBuildItem launchMode,
+            MqttBuildTimeConfig mqttClientBuildTimeConfig,
+            Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
+            LoggingSetupBuildItem loggingSetupBuildItem,
+            GlobalDevServicesConfig devServicesConfig) {
+
+        MqttDevServiceCfg configuration = getConfiguration(mqttClientBuildTimeConfig);
+
+        if (devService != null) {
+            boolean shouldShutdownTheBroker = !configuration.equals(cfg);
+            if (!shouldShutdownTheBroker) {
+                return devService.toBuildItem();
+            }
+            shutdownBroker();
+            cfg = null;
+        }
+
+        StartupLogCompressor compressor = new StartupLogCompressor(
+                (launchMode.isTest() ? "(test) " : "") + "MQTT Dev Services Starting:", consoleInstalledBuildItem,
+                loggingSetupBuildItem);
+        try {
+            RunningDevService newDevService = startMqttBroker(dockerStatusBuildItem, configuration, launchMode,
+                    devServicesConfig.timeout);
+            if (newDevService != null) {
+                devService = newDevService;
+
+                Map<String, String> config = devService.getConfig();
+                if (devService.isOwner()) {
+                    log.info("Dev Services for MQTT started.");
+                }
+            }
+            if (devService == null) {
+                compressor.closeAndDumpCaptured();
+            } else {
+                compressor.close();
+            }
+        } catch (Throwable t) {
+            compressor.closeAndDumpCaptured();
+            throw new RuntimeException(t);
+        }
+
+        if (devService == null) {
+            return null;
+        }
+
+        // Configure the watch dog
+        if (first) {
+            first = false;
+            Runnable closeTask = () -> {
+                if (devService != null) {
+                    shutdownBroker();
+
+                    log.info("Dev Services for MQTT shut down.");
+                }
+                first = true;
+                devService = null;
+                cfg = null;
+            };
+            QuarkusClassLoader cl = (QuarkusClassLoader) Thread.currentThread().getContextClassLoader();
+            ((QuarkusClassLoader) cl.parent()).addCloseTask(closeTask);
+        }
+        cfg = configuration;
+        return devService.toBuildItem();
+    }
+
+    private void shutdownBroker() {
+        if (devService != null) {
+            try {
+                devService.close();
+            } catch (Throwable e) {
+                log.error("Failed to stop the MQTT broker", e);
+            } finally {
+                devService = null;
+            }
+        }
+    }
+
+    private RunningDevService startMqttBroker(DockerStatusBuildItem dockerStatusBuildItem,
+            MqttDevServiceCfg config, LaunchModeBuildItem launchMode,
+            Optional<Duration> timeout) {
+        if (!config.devServicesEnabled) {
+            // explicitly disabled
+            log.debug("Not starting Dev Services for MQTT, as it has been disabled in the config.");
+            return null;
+        }
+
+        // Verify that we have MQTT channels without host and port
+        if (!hasMqttChannelWithoutHostAndPort()) {
+            log.debug("Not starting Dev Services for MQTT, all the channels are configured.");
+            return null;
+        }
+
+        if (!dockerStatusBuildItem.isDockerAvailable()) {
+            log.warn("Docker isn't working, please configure the MQTT broker location.");
+            return null;
+        }
+
+        ConfiguredMqttContainer container = new ConfiguredMqttContainer(
+                DockerImageName.parse(config.imageName).asCompatibleSubstituteFor("mqtt"),
+                config.fixedExposedPort,
+                launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT ? config.serviceName : null);
+
+        final Supplier<RunningDevService> defaultMqttBrokerSupplier = () -> {
+
+            // Starting the broker
+            timeout.ifPresent(container::withStartupTimeout);
+            container.withEnv(config.containerEnv);
+            container.start();
+            return getRunningDevService(
+                    container.getContainerId(),
+                    container::close,
+                    container.getHost(),
+                    container.getPort());
+        };
+
+        return mqttContainerLocator
+                .locateContainer(
+                        config.serviceName,
+                        config.shared,
+                        launchMode.getLaunchMode())
+                .map(containerAddress -> getRunningDevService(
+                        containerAddress.getId(),
+                        null,
+                        containerAddress.getHost(),
+                        containerAddress.getPort()))
+                .orElseGet(defaultMqttBrokerSupplier);
+    }
+
+    private RunningDevService getRunningDevService(
+            String containerId,
+            Closeable closeable,
+            String host,
+            int port) {
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put("mp.messaging.connector.smallrye-mqtt-hivemq.host", host);
+        configMap.put("mp.messaging.connector.smallrye-mqtt-hivemq.port", String.valueOf(port));
+        return new RunningDevService(Feature.SMALLRYE_REACTIVE_MESSAGING_MQTT.getName(),
+                containerId, closeable, configMap);
+    }
+
+    private boolean hasMqttChannelWithoutHostAndPort() {
+        Config config = ConfigProvider.getConfig();
+        boolean isConfigured;
+        for (String name : config.getPropertyNames()) {
+            boolean isIncoming = name.startsWith("mp.messaging.incoming.");
+            boolean isOutgoing = name.startsWith("mp.messaging.outgoing.");
+            boolean isConnector = name.endsWith(".connector");
+            if ((isIncoming || isOutgoing) && isConnector) {
+                String connectorValue = config.getValue(name, String.class);
+                boolean isMqtt = connectorValue.equalsIgnoreCase("smallrye-mqtt-hivemq");
+                boolean hasHost = ConfigUtils.isPropertyPresent(name.replace(".connector", ".host"));
+                boolean hasPort = ConfigUtils.isPropertyPresent(name.replace(".connector", ".port"));
+                isConfigured = isMqtt && (hasHost || hasPort);
+
+                if (!isConfigured) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private MqttDevServiceCfg getConfiguration(MqttBuildTimeConfig cfg) {
+        MqttDevServicesBuildTimeConfig devServicesConfig = cfg.devservices;
+        return new MqttDevServiceCfg(devServicesConfig);
+    }
+
+    private static final class MqttDevServiceCfg {
+
+        private final boolean devServicesEnabled;
+        private final String imageName;
+        private final Integer fixedExposedPort;
+        private final boolean shared;
+        private final String serviceName;
+        private final Map<String, String> containerEnv;
+
+        public MqttDevServiceCfg(MqttDevServicesBuildTimeConfig devServicesConfig) {
+            this.devServicesEnabled = devServicesConfig.enabled.orElse(true);
+            this.imageName = devServicesConfig.imageName;
+            this.fixedExposedPort = devServicesConfig.port.orElse(0);
+            this.shared = devServicesConfig.shared;
+            this.serviceName = devServicesConfig.serviceName;
+            this.containerEnv = devServicesConfig.containerEnv;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            MqttDevServiceCfg that = (MqttDevServiceCfg) o;
+            return devServicesEnabled == that.devServicesEnabled && Objects.equals(imageName, that.imageName)
+                    && Objects.equals(fixedExposedPort, that.fixedExposedPort)
+                    && Objects.equals(containerEnv, that.containerEnv);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(devServicesEnabled, imageName, fixedExposedPort, containerEnv);
+        }
+    }
+
+    /**
+     * Container configuring and starting the HiveMQ broker.
+     */
+    private static final class ConfiguredMqttContainer extends GenericContainer<ConfiguredMqttContainer> {
+
+        private final int port;
+
+        private ConfiguredMqttContainer(
+                DockerImageName dockerImageName,
+                int fixedExposedPort,
+                String serviceName) {
+            super(dockerImageName);
+            this.port = fixedExposedPort;
+            withExposedPorts(MQTT_PORT);
+            withNetwork(Network.SHARED);
+            if (serviceName != null) { // Only adds the label in dev mode.
+                withLabel(DEV_SERVICE_LABEL, serviceName);
+            }
+        }
+
+        @Override
+        protected void configure() {
+            super.configure();
+            if (port > 0) {
+                addFixedExposedPort(port, MQTT_PORT);
+            }
+        }
+
+        public int getPort() {
+            return getMappedPort(MQTT_PORT);
+        }
+    }
+}

--- a/integration-tests/hivemq-client-smallrye/pom.xml
+++ b/integration-tests/hivemq-client-smallrye/pom.xml
@@ -11,9 +11,9 @@
     <name>Quarkus - Hivemq Client - Integration Tests smallrye</name>
 
     <properties>
+        <surefire-plugin.version>3.2.2</surefire-plugin.version>
         <hive.testcontainers.version>1.19.2</hive.testcontainers.version>
-        <exclude.quarkus.native.tests>**/*Native*IT.java</exclude.quarkus.native.tests>
-        <include.tests>**/*Test.java</include.tests>
+        <include.tests>**/*IT.java</include.tests>
     </properties>
 
     <dependencies>
@@ -21,10 +21,12 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-reactive</artifactId>
         </dependency>
+
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-reactive-messaging-mqtt</artifactId>
+            <artifactId>quarkus-smallrye-reactive-messaging</artifactId>
         </dependency>
+
         <dependency>
             <groupId>io.quarkiverse.hivemqclient</groupId>
             <artifactId>quarkus-hivemq-client</artifactId>
@@ -70,6 +72,17 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>${failsafe-plugin.version}</version>
                 <executions>
@@ -79,9 +92,6 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
-                            <excludes>
-                                <exclude>${exclude.quarkus.native.tests}</exclude>
-                            </excludes>
                             <includes>
                                 <include>${include.tests}</include>
                             </includes>

--- a/integration-tests/hivemq-client-smallrye/src/main/resources/application.properties
+++ b/integration-tests/hivemq-client-smallrye/src/main/resources/application.properties
@@ -1,13 +1,9 @@
 # Configure the MQTT sink (we write to it)
-mp.messaging.outgoing.topic-price.type=smallrye-mqtt-hivemq
+mp.messaging.outgoing.topic-price.connector=smallrye-mqtt-hivemq
 mp.messaging.outgoing.topic-price.topic=prices
-mp.messaging.outgoing.topic-price.host=localhost
-mp.messaging.outgoing.topic-price.port=1883
 mp.messaging.outgoing.topic-price.auto-generated-client-id=true
 
 # Configure the MQTT source (we read from it)
-mp.messaging.incoming.prices.type=smallrye-mqtt-hivemq
+mp.messaging.incoming.prices.connector=smallrye-mqtt-hivemq
 mp.messaging.incoming.prices.topic=prices
-mp.messaging.incoming.prices.host=localhost
-mp.messaging.incoming.prices.port=1883
 mp.messaging.incoming.prices.auto-generated-client-id=true

--- a/integration-tests/hivemq-client-smallrye/src/test/java/io/quarkiverse/hivemqclient/test/smallrye/DevServiceNoAuthPriceTest.java
+++ b/integration-tests/hivemq-client-smallrye/src/test/java/io/quarkiverse/hivemqclient/test/smallrye/DevServiceNoAuthPriceTest.java
@@ -1,0 +1,7 @@
+package io.quarkiverse.hivemqclient.test.smallrye;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class DevServiceNoAuthPriceTest extends CommonScenarios {
+}

--- a/integration-tests/kitchensink/pom.xml
+++ b/integration-tests/kitchensink/pom.xml
@@ -25,10 +25,12 @@
       <artifactId>quarkus-hivemq-client</artifactId>
       <version>${project.version}</version>
     </dependency>
+
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-smallrye-reactive-messaging-mqtt</artifactId>
+      <artifactId>quarkus-smallrye-reactive-messaging</artifactId>
     </dependency>
+
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-arc</artifactId>


### PR DESCRIPTION
close #103 

## Description

If `mp.messaging.incoming/outcome.host` and `mp.messaging.incoming/outcome.port` is not provided then a hiveMQ broker should be launched in a random port. 

