### PR TITLE
Align smallrye reactive messaging version with Quarkus  2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <smallrye-reactive-messaging-mqtt.version>4.11.0</smallrye-reactive-messaging-mqtt.version>
+    <smallrye-reactive-messaging-mqtt.version>3.22.1</smallrye-reactive-messaging-mqtt.version>
     <microprofile-reactive-streams.version>1.0.1</microprofile-reactive-streams.version>
     <microprofile-metrics-api.version>3.0.1</microprofile-metrics-api.version>
     <impsort-maven-plugin.version>1.9.0</impsort-maven-plugin.version>


### PR DESCRIPTION
Downgrade smallrye reactive messaging version to the same version used on Quarkus 2.16 BOM

[Quarkus 2.x reference](https://github.com/quarkusio/quarkus/blob/2.16/bom/application/pom.xml#L59C4-L59C4)