### PR TITLE
Add Java distribution to github action javaSetup (release.yml)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,9 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: 11
+          check-latest: true
 
       - name: Cache local Maven repository
         uses: actions/cache@v3


### PR DESCRIPTION
I am getting the following error when I perform a release

`Input required and not supplied: distribution`

Job Ref: https://github.com/quarkiverse/quarkus-hivemq-client/actions/runs/7098129355

This PR is fixing the above issue. 