### PR TITLE
Quarkus 3.x migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
@@ -53,7 +53,7 @@ jobs:
     needs: validate-format
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
     steps:
     - uses: actions/checkout@v4
     - name: Install JDK {{ matrix.java }}
@@ -81,7 +81,7 @@ jobs:
     needs: validate-format
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 17 ]
         image: [ "ubi-quarkus-native-image:22.3-java17", "ubi-quarkus-mandrel:22.3-java17", "ubi-quarkus-graalvmce-builder-image:22.3-java17" ]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
@@ -34,7 +34,7 @@ jobs:
     needs: validate-format
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
     steps:
       - uses: actions/checkout@v4
       - name: Install JDK {{ matrix.java }}
@@ -62,7 +62,7 @@ jobs:
     needs: validate-format
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 17 ]
         image: [ "ubi-quarkus-native-image:22.3-java17", "ubi-quarkus-mandrel:22.3-java17", "ubi-quarkus-graalvmce-builder-image:22.3-java17" ]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -10,7 +10,7 @@ on:
 env:
   ECOSYSTEM_CI_REPO: quarkusio/quarkus-ecosystem-ci
   ECOSYSTEM_CI_REPO_FILE: context.yaml
-  JAVA_VERSION: 11 # move to Java 17 on Quarkus 3.x branch
+  JAVA_VERSION: 17
 
   #########################
   # Repo specific setting #

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
           check-latest: true
 
       - name: Cache local Maven repository

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -88,7 +88,7 @@ package inbound;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
 public class MqttPriceConsumer {

--- a/integration-tests/hivemq-client-smallrye/src/main/java/io/quarkiverse/hivemqclient/test/smallrye/PriceConverter.java
+++ b/integration-tests/hivemq-client-smallrye/src/main/java/io/quarkiverse/hivemqclient/test/smallrye/PriceConverter.java
@@ -1,12 +1,12 @@
 package io.quarkiverse.hivemqclient.test.smallrye;
 
+import jakarta.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.jboss.logging.Logger;
 
 import io.smallrye.reactive.messaging.annotations.Broadcast;
-
-import javax.enterprise.context.ApplicationScoped;
 
 /**
  * A bean consuming data from the "prices" MQTT topic and applying some conversion.

--- a/integration-tests/hivemq-client-smallrye/src/main/java/io/quarkiverse/hivemqclient/test/smallrye/PriceGenerator.java
+++ b/integration-tests/hivemq-client-smallrye/src/main/java/io/quarkiverse/hivemqclient/test/smallrye/PriceGenerator.java
@@ -3,12 +3,12 @@ package io.quarkiverse.hivemqclient.test.smallrye;
 import java.time.Duration;
 import java.util.Random;
 
+import jakarta.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.jboss.logging.Logger;
 
 import io.smallrye.mutiny.Multi;
-
-import javax.enterprise.context.ApplicationScoped;
 
 /**
  * A bean producing random prices every second.

--- a/integration-tests/hivemq-client-smallrye/src/main/java/io/quarkiverse/hivemqclient/test/smallrye/PriceResource.java
+++ b/integration-tests/hivemq-client-smallrye/src/main/java/io/quarkiverse/hivemqclient/test/smallrye/PriceResource.java
@@ -1,14 +1,15 @@
 package io.quarkiverse.hivemqclient.test.smallrye;
 
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
 import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.jboss.resteasy.reactive.RestStreamElementType;
 
 import io.smallrye.mutiny.Multi;
-
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 /**
  * A simple resource retrieving the "in-memory" "my-data-stream" and sending the items to a server sent event.
@@ -28,7 +29,7 @@ public class PriceResource {
 
     @GET
     @Path("/stream")
-    @Produces(MediaType.SERVER_SENT_EVENTS)
+    @RestStreamElementType(MediaType.APPLICATION_JSON)
     public Multi<Double> stream() {
         return prices;
     }

--- a/integration-tests/kitchensink/src/main/java/io/quarkiverse/hivemqclient/GreetingResource.java
+++ b/integration-tests/kitchensink/src/main/java/io/quarkiverse/hivemqclient/GreetingResource.java
@@ -1,19 +1,22 @@
 package io.quarkiverse.hivemqclient;
 
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.OnOverflow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.smallrye.reactive.messaging.mqtt.MqttMessage;
 
-import javax.inject.Inject;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
@@ -21,9 +24,11 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class GreetingResource {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(GreetingResource.class);
+
     @Incoming("incoming-messages")
     public void creaOAggiornaTerminale(byte[] incoming) {
-        log.info("new payload: {}", new String(incoming));
+        LOGGER.info("new payload: {}", new String(incoming));
     }
 
     @Channel("commands")

--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,9 @@
   <properties>
     <compiler-plugin.version>3.10.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
-    <maven.compiler.release>11</maven.compiler.release>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <smallrye-reactive-messaging-mqtt.version>3.22.1</smallrye-reactive-messaging-mqtt.version>
@@ -40,7 +40,7 @@
     <src.sort.goal>sort</src.sort.goal>
     <hivemq.client.version>1.3.3</hivemq.client.version>
     <checkstyle.version>10.12.5</checkstyle.version>
-    <quarkus.version>2.16.12.Final</quarkus.version>
+    <quarkus.version>3.2.9.Final</quarkus.version>
     <failsafe-plugin.version>3.2.2</failsafe-plugin.version>
   </properties>
   <dependencyManagement>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -25,10 +25,6 @@
       <artifactId>smallrye-reactive-messaging-mqtt</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.smallrye.reactive</groupId>
-      <artifactId>mutiny-rxjava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>
       <artifactId>microprofile-reactive-streams-operators-api</artifactId>
     </dependency>
@@ -59,8 +55,7 @@
       </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-        <version>${quarkus.version}</version>
+        <artifactId>quarkus-extension-maven-plugin</artifactId>
         <executions>
           <execution>
             <phase>compile</phase>
@@ -72,6 +67,18 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>io.quarkus</groupId>
+              <artifactId>quarkus-extension-processor</artifactId>
+              <version>${quarkus.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
close #108 

## Description

- Migrate from Quarkus 2.x to Quarkus 3.x
- Javax to Jakarta
- RxJava2.x to RxJava3.x

## TODO

- There are still some classes related to security pointing to Javax, but this is going to be done in another PR. 