### PR TITLE
Release 2.1.0: Quarkus 3.7.3 + bug fixes

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: 2.0.0
-  next-version: 2.0.1-SNAPSHOT
+  current-version: 2.1.0
+  next-version: 2.1.1-SNAPSHOT

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -20,6 +20,9 @@ This adds some benefits to the original SmallRye MQTT:
 
 |===
 | Quarkus-hivemq-client version | Quarkus version | HiveMQ client version
+| 2.1.0
+| 3.7.3
+| 1.3.3
 | 2.0.0
 | 3.6.5
 | 1.3.3


### PR DESCRIPTION
- Quarkus 3.7.3
- [bugFix](https://github.com/quarkiverse/quarkus-hivemq-client/commit/733d76990a81aabcbeedbe9dc4cccb10cee441e3)