### PR TITLE
Rollback release 2.1.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: 2.1.0
-  next-version: 2.1.1-SNAPSHOT
+  current-version: 2.0.0
+  next-version: 2.0.1-SNAPSHOT

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -20,9 +20,6 @@ This adds some benefits to the original SmallRye MQTT:
 
 |===
 | Quarkus-hivemq-client version | Quarkus version | HiveMQ client version
-| 2.1.0
-| 3.7.3
-| 1.3.3
 | 2.0.0
 | 3.6.5
 | 1.3.3


### PR DESCRIPTION
Due to an [error](https://github.com/quarkiverse/quarkus-hivemq-client/actions/runs/7941918037) on CI, we are going to do a release rollback