### PR TITLE
Latest HiveMQ test containers is failing due to a reported issue

### DIFF
--- a/integration-tests/hivemq-client-smallrye/src/test/java/io/quarkiverse/hivemqclient/test/smallrye/resources/CommonResources.java
+++ b/integration-tests/hivemq-client-smallrye/src/test/java/io/quarkiverse/hivemqclient/test/smallrye/resources/CommonResources.java
@@ -13,7 +13,7 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 public class CommonResources implements QuarkusTestResourceLifecycleManager {
 
     private final static Level LOG_LEVEL = Level.DEBUG;
-    protected final static HiveMQContainer hivemqContainer = new HiveMQContainer(parse("hivemq/hivemq-ce"))
+    protected final static HiveMQContainer hivemqContainer = new HiveMQContainer(parse("hivemq/hivemq-ce").withTag("2024.2"))
             .withLogLevel(LOG_LEVEL);
 
     @Override


### PR DESCRIPTION
Due to a known [issue](https://github.com/hivemq/hivemq-community-edition/issues/468) on HiveMQ testcontainer `2024.3` we are going to downgrade the docker image from latest to `2024.2`