### PR TITLE
Release 2.2.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: 2.1.0
-  next-version: 2.1.1-SNAPSHOT
+  current-version: 2.2.0
+  next-version: 2.2.1-SNAPSHOT


### PR DESCRIPTION
- Quarkus 3.8.1
- Support HiveMQ Cloud Serverless 
- Support SSL `trust-all`