### PR TITLE
Improve startup logs - Wrong credentials parameters

### DIFF
--- a/integration-tests/hivemq-client-smallrye/src/test/java/io/quarkiverse/hivemqclient/test/smallrye/CommonScenarios.java
+++ b/integration-tests/hivemq-client-smallrye/src/test/java/io/quarkiverse/hivemqclient/test/smallrye/CommonScenarios.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.common.http.TestHTTPResource;
 
 public class CommonScenarios {
-    private static final int TIMEOUT_SEC = 5;
+    private static final int TIMEOUT_SEC = 10;
     private static final Logger LOG = Logger.getLogger(CommonScenarios.class);
 
     @TestHTTPResource("prices/stream")

--- a/runtime/src/main/java/io/quarkiverse/hivemqclient/smallrye/reactive/HiveMQClients.java
+++ b/runtime/src/main/java/io/quarkiverse/hivemqclient/smallrye/reactive/HiveMQClients.java
@@ -179,7 +179,13 @@ public class HiveMQClients {
             }
 
             connection = Uni.createFrom().future(client.connect().toFuture());
-            connection.subscribe().with(c -> log.info(c.getReturnCode()));
+            connection.subscribe().with(
+                    c -> {
+                        log.info("Mqtt3 connection Ack: " + c.getReturnCode());
+                    },
+                    failure -> {
+                        log.error("Failed to connect to MQTT broker: " + failure.getMessage(), failure);
+                    });
 
         }
 

--- a/runtime/src/main/java/io/quarkiverse/hivemqclient/smallrye/reactive/HiveMQPing.java
+++ b/runtime/src/main/java/io/quarkiverse/hivemqclient/smallrye/reactive/HiveMQPing.java
@@ -1,0 +1,98 @@
+package io.quarkiverse.hivemqclient.smallrye.reactive;
+
+import static io.smallrye.reactive.messaging.mqtt.i18n.MqttLogging.log;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import com.hivemq.client.mqtt.datatypes.MqttQos;
+import com.hivemq.client.mqtt.mqtt3.Mqtt3AsyncClient;
+
+public class HiveMQPing {
+
+    private final static int PING_TIMEOUT_SEC = 15;
+    private final static String DEFAULT_ERROR_MSG = """
+                Unable to reach HiveMQ server.
+                Possible causes:
+                - Incorrect host or port (check your broker address).
+                - Authentication failure (verify username/password).
+                - The MQTT broker is down or unreachable.
+                - Network issues (firewall, VPN, or DNS misconfiguration).
+
+                Please review your configuration and try again.
+            """;
+
+    private HiveMQPing() {
+    }
+
+    public static boolean isServerReachable(HiveMQClients.ClientHolder holder) {
+        Mqtt3AsyncClient clientAsync = initializeMqttClient(holder);
+        if (clientAsync == null || !HiveMQPing.checkConnection(clientAsync)) {
+            log.warn(DEFAULT_ERROR_MSG);
+            return false;
+        }
+
+        return true;
+    }
+
+    private static boolean checkConnection(Mqtt3AsyncClient client) {
+        CompletableFuture<Boolean> pongReceived = new CompletableFuture<>();
+        String pongTopic = "pong";
+        try {
+            if (!client.getConfig().getState().isConnected()) {
+                client.connect()
+                        .whenComplete((connAck, throwable) -> {
+                            if (throwable != null) {
+                                log.unableToConnectToBroker(throwable);
+                            }
+                        }).get(5, TimeUnit.SECONDS);
+            }
+
+            if (!client.getConfig().getState().isConnected()) {
+                log.unableToConnectToBroker(new Exception("Client is not connected"));
+                return false;
+            }
+
+            client.subscribeWith()
+                    .topicFilter(pongTopic)
+                    .qos(MqttQos.AT_LEAST_ONCE)
+                    .callback(publish -> {
+                        String payload = new String(publish.getPayloadAsBytes());
+                        if ("ping".equals(payload)) {
+                            pongReceived.complete(true);
+                        }
+                    })
+                    .send()
+                    .get(5, TimeUnit.SECONDS);
+
+            Thread.sleep(500);
+
+            client.publishWith()
+                    .topic(pongTopic)
+                    .qos(MqttQos.AT_LEAST_ONCE)
+                    .payload("ping".getBytes())
+                    .send()
+                    .get(5, TimeUnit.SECONDS);
+
+            return pongReceived.get(PING_TIMEOUT_SEC, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            return false;
+        } finally {
+            client.unsubscribeWith()
+                    .topicFilter(pongTopic)
+                    .send();
+        }
+    }
+
+    private static Mqtt3AsyncClient initializeMqttClient(HiveMQClients.ClientHolder holder) {
+        try {
+            return holder.connect()
+                    .await().atMost(Duration.ofSeconds(10))
+                    .toAsync();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
close #316 

At the start of the application, a ping will be sent to the MQTT server from both the publisher and the subscriber. If the ping fails, the following warning will be displayed:

> Unable to reach HiveMQ server.
            Possible causes:
            - Incorrect host or port (check your broker address).
            - Authentication failure (verify username/password).
            - The MQTT broker is down or unreachable.
            - Network issues (firewall, VPN, or DNS misconfiguration).

            Please review your configuration and try again.