### PR TITLE
Fix: Disable MQTT devservice for tests

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/hivemqclient/deployment/MqttDevServicesProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/hivemqclient/deployment/MqttDevServicesProcessor.java
@@ -218,12 +218,18 @@ public class MqttDevServicesProcessor {
 
     private MqttDevServiceCfg getConfiguration() {
         Config config = ConfigProvider.getConfig();
-        boolean devServicesEnabled = config.getOptionalValue("hivemq.devservices.enabled", Boolean.class).orElse(true);
-        String imageName = config.getOptionalValue("hivemq.devservices.image-name", String.class).orElse("hivemq/hivemq4");
-        Integer fixedExposedPort = config.getOptionalValue("hivemq.devservices.port", Integer.class).orElse(0);
-        boolean shared = config.getOptionalValue("hivemq.devservices.shared", Boolean.class).orElse(false);
-        String serviceName = config.getOptionalValue("hivemq.devservices.service-name", String.class).orElse("mqtt");
+        boolean globalDevServiceEnabled = config.getOptionalValue("quarkus.devservices.enabled", Boolean.class).orElse(true);
+        boolean mqttDevServiceEnabled = config.getOptionalValue("quarkus.hivemq.devservices.enabled", Boolean.class)
+                .orElse(true);
+
+        boolean devServicesEnabled = globalDevServiceEnabled && mqttDevServiceEnabled;
+        String imageName = config.getOptionalValue("quarkus.hivemq.devservices.image-name", String.class)
+                .orElse("hivemq/hivemq4");
+        Integer fixedExposedPort = config.getOptionalValue("quarkus.hivemq.devservices.port", Integer.class).orElse(0);
+        boolean shared = config.getOptionalValue("quarkus.hivemq.devservices.shared", Boolean.class).orElse(false);
+        String serviceName = config.getOptionalValue("quarkus.hivemq.devservices.service-name", String.class).orElse("mqtt");
         Map<String, String> containerEnv = new HashMap<>();
+
         return new MqttDevServiceCfg(new MqttDevServicesBuildTimeConfig(devServicesEnabled, imageName, fixedExposedPort, shared,
                 serviceName, containerEnv));
     }

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -174,4 +174,27 @@ for example, you can run `mvn -V -B -am clean verify -Dnative -Dquarkus.native.b
 
 == Dev Services
 
-If no `outgoing/incoming host/port` is defined then Dev Services will launch a default instance and will connect your channels to the HiveMQ broker.
+The **Dev Services** feature in the HiveMQ Quarkus extension simplifies the integration of a local MQTT broker in your application for testing and development. If no custom host/port configuration is defined, Dev Services will automatically launch an instance of the MQTT broker and connect your messaging channels to it.
+
+The configuration for Dev Services can be controlled via the `application.properties` file. The following properties are available for customization:
+
+[source,properties]
+----
+# Enable/Disable DevServices globally
+quarkus.devservices.enabled=true
+
+# Enable/Disable MQTT DevServices specifically
+quarkus.hivemq.devservices.enabled=true
+
+# Set the image name for the MQTT broker (defaults to 'hivemq/hivemq4')
+quarkus.hivemq.devservices.image-name=hivemq/hivemq4
+
+# Set a fixed port for the MQTT broker (set to 0 to let Docker pick an available port)
+quarkus.hivemq.devservices.port=0
+
+# Configure whether the DevService should be shared across multiple tests
+quarkus.hivemq.devservices.shared=false
+
+# Set a custom service name for the DevService container
+quarkus.hivemq.devservices.service-name=mqtt
+----

--- a/integration-tests/hivemq-client-smallrye/src/main/resources/application.properties
+++ b/integration-tests/hivemq-client-smallrye/src/main/resources/application.properties
@@ -16,3 +16,6 @@ mp.messaging.incoming.prices.auto-generated-client-id=true
 mp.messaging.incoming.custom-topic-sink.connector=smallrye-mqtt-hivemq
 mp.messaging.incoming.custom-topic-sink.topic=custom-topic
 mp.messaging.incoming.custom-topic-sink.auto-generated-client-id=true
+
+quarkus.hivemq.devservices.enabled=false
+%dev-service.quarkus.hivemq.devservices.enabled=true

--- a/integration-tests/hivemq-client-smallrye/src/test/java/io/quarkiverse/hivemqclient/test/smallrye/DevServiceNoAuthPriceTest.java
+++ b/integration-tests/hivemq-client-smallrye/src/test/java/io/quarkiverse/hivemqclient/test/smallrye/DevServiceNoAuthPriceTest.java
@@ -1,7 +1,10 @@
 package io.quarkiverse.hivemqclient.test.smallrye;
 
+import io.quarkiverse.hivemqclient.test.smallrye.resources.HivemqProfiles;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 
+@TestProfile(HivemqProfiles.DevServiceEnabled.class)
 @QuarkusTest
 public class DevServiceNoAuthPriceTest extends CommonScenarios {
 }

--- a/integration-tests/hivemq-client-smallrye/src/test/java/io/quarkiverse/hivemqclient/test/smallrye/resources/CommonResources.java
+++ b/integration-tests/hivemq-client-smallrye/src/test/java/io/quarkiverse/hivemqclient/test/smallrye/resources/CommonResources.java
@@ -19,6 +19,12 @@ public abstract class CommonResources implements QuarkusTestResourceLifecycleMan
         config.put("mp.messaging.outgoing.topic-price.port", "" + getHiveMQContainer().getMqttPort());
         config.put("mp.messaging.incoming.prices.host", getHiveMQContainer().getHost());
         config.put("mp.messaging.incoming.prices.port", "" + getHiveMQContainer().getMqttPort());
+
+        // custom topic scenario
+        config.put("mp.messaging.incoming.custom-topic-sink.host", getHiveMQContainer().getHost());
+        config.put("mp.messaging.incoming.custom-topic-sink.port", "" + getHiveMQContainer().getMqttPort());
+        config.put("mp.messaging.outgoing.custom-topic.host", getHiveMQContainer().getHost());
+        config.put("mp.messaging.outgoing.custom-topic.port", "" + getHiveMQContainer().getMqttPort());
         return config;
     }
 

--- a/integration-tests/hivemq-client-smallrye/src/test/java/io/quarkiverse/hivemqclient/test/smallrye/resources/HivemqProfiles.java
+++ b/integration-tests/hivemq-client-smallrye/src/test/java/io/quarkiverse/hivemqclient/test/smallrye/resources/HivemqProfiles.java
@@ -40,4 +40,11 @@ public class HivemqProfiles {
             return Collections.singletonList(new TestResourceEntry(EnterpriseJwtAuthResources.class));
         }
     }
+
+    public static class DevServiceEnabled implements QuarkusTestProfile {
+        @Override
+        public String getConfigProfile() {
+            return "dev-service";
+        }
+    }
 }

--- a/integration-tests/hivemq-client-smallrye/src/test/java/io/quarkiverse/hivemqclient/test/smallrye/resources/MtlsAuthResources.java
+++ b/integration-tests/hivemq-client-smallrye/src/test/java/io/quarkiverse/hivemqclient/test/smallrye/resources/MtlsAuthResources.java
@@ -48,6 +48,25 @@ public class MtlsAuthResources extends HiveMQCommunityEdition {
         config.put("mp.messaging.incoming.prices.ssl.truststore.password", "changeme");
         config.put("mp.messaging.incoming.prices.ssl.truststore.hostVerifier", "false");
 
+        config.put("mp.messaging.outgoing.custom-topic.ssl", "true");
+        config.put("mp.messaging.outgoing.custom-topic.ssl.keystore.type", "jks");
+        config.put("mp.messaging.outgoing.custom-topic.ssl.keystore.location", "src/test/resources/certs/client-keystore.jks");
+        config.put("mp.messaging.outgoing.custom-topic.ssl.keystore.password", "changeme");
+        config.put("mp.messaging.outgoing.custom-topic.ssl.truststore.type", "jks");
+        config.put("mp.messaging.outgoing.custom-topic.ssl.truststore.location", "src/test/resources/certs/server.jks");
+        config.put("mp.messaging.outgoing.custom-topic.ssl.truststore.password", "changeme");
+        config.put("mp.messaging.outgoing.custom-topic.ssl.truststore.hostVerifier", "false");
+
+        config.put("mp.messaging.incoming.custom-topic-sink.ssl", "true");
+        config.put("mp.messaging.incoming.custom-topic-sink.ssl.keystore.type", "jks");
+        config.put("mp.messaging.incoming.custom-topic-sink.ssl.keystore.location",
+                "src/test/resources/certs/client-keystore.jks");
+        config.put("mp.messaging.incoming.custom-topic-sink.ssl.keystore.password", "changeme");
+        config.put("mp.messaging.incoming.custom-topic-sink.ssl.truststore.type", "jks");
+        config.put("mp.messaging.incoming.custom-topic-sink.ssl.truststore.location", "src/test/resources/certs/server.jks");
+        config.put("mp.messaging.incoming.custom-topic-sink.ssl.truststore.password", "changeme");
+        config.put("mp.messaging.incoming.custom-topic-sink.ssl.truststore.hostVerifier", "false");
+
         return config;
     }
 }

--- a/integration-tests/hivemq-client-smallrye/src/test/java/io/quarkiverse/hivemqclient/test/smallrye/resources/RbacAuthResources.java
+++ b/integration-tests/hivemq-client-smallrye/src/test/java/io/quarkiverse/hivemqclient/test/smallrye/resources/RbacAuthResources.java
@@ -24,6 +24,10 @@ public class RbacAuthResources extends HiveMQCommunityEdition {
         config.put("mp.messaging.outgoing.topic-price.password", DEFAULT_PASSWORD);
         config.put("mp.messaging.incoming.prices.username", DEFAULT_USERNAME);
         config.put("mp.messaging.incoming.prices.password", DEFAULT_PASSWORD);
+        config.put("mp.messaging.incoming.custom-topic-sink.username", DEFAULT_USERNAME);
+        config.put("mp.messaging.incoming.custom-topic-sink.password", DEFAULT_PASSWORD);
+        config.put("mp.messaging.outgoing.custom-topic.username", DEFAULT_USERNAME);
+        config.put("mp.messaging.outgoing.custom-topic.password", DEFAULT_PASSWORD);
         return config;
     }
 }

--- a/integration-tests/hivemq-client-smallrye/src/test/java/io/quarkiverse/hivemqclient/test/smallrye/resources/TlsAuthResources.java
+++ b/integration-tests/hivemq-client-smallrye/src/test/java/io/quarkiverse/hivemqclient/test/smallrye/resources/TlsAuthResources.java
@@ -33,6 +33,17 @@ public class TlsAuthResources extends HiveMQCommunityEdition {
         config.put("mp.messaging.incoming.prices.ssl.truststore.password", "changeme");
         config.put("mp.messaging.incoming.prices.ssl.truststore.hostVerifier", "false");
 
+        config.put("mp.messaging.outgoing.custom-topic.ssl", "true");
+        config.put("mp.messaging.outgoing.custom-topic.ssl.truststore.type", "jks");
+        config.put("mp.messaging.outgoing.custom-topic.ssl.truststore.location", "src/test/resources/certs/server.jks");
+        config.put("mp.messaging.outgoing.custom-topic.ssl.truststore.password", "changeme");
+        config.put("mp.messaging.outgoing.custom-topic.ssl.truststore.hostVerifier", "false");
+
+        config.put("mp.messaging.incoming.custom-topic-sink.ssl", "true");
+        config.put("mp.messaging.incoming.custom-topic-sink.ssl.truststore.type", "jks");
+        config.put("mp.messaging.incoming.custom-topic-sink.ssl.truststore.location", "src/test/resources/certs/server.jks");
+        config.put("mp.messaging.incoming.custom-topic-sink.ssl.truststore.password", "changeme");
+        config.put("mp.messaging.incoming.custom-topic-sink.ssl.truststore.hostVerifier", "false");
         return config;
     }
 }


### PR DESCRIPTION
This PR introduces the ability to enable or disable Dev Services in Quarkus tests, providing greater flexibility for test configurations.

- **Enable/Disable Dev Services in Tests**: Added functionality to allow Dev Services to be enabled or disabled in specific tests. This gives developers more control over whether they want to use Dev Services in their test environments.

- **Improved Documentation**: Enhanced the documentation regarding the Dev Services functionality, particularly focusing on its configuration and usage within tests. This provides clearer instructions on how to control Dev Services in different testing scenarios.

close #317 