### PR TITLE
Fix native flaky test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,33 +74,33 @@ jobs:
       run: tar -xzf maven-repo.tgz -C ~
     - name: Build with Maven
       run: mvn -V -B -am clean verify
-#  linux-build-native:
-#    name: PR - Linux - Native build - Latest Version
-#    runs-on: ubuntu-latest
-#    timeout-minutes: 60
-#    needs: validate-format
-#    strategy:
-#      matrix:
-#        java: [ 17, 21 ]
-#        image: [ "ubi-quarkus-mandrel-builder-image:jdk-21", "ubi-quarkus-graalvmce-builder-image:jdk-21" ]
-#    steps:
-#    - uses: actions/checkout@v4
-#    - name: Install JDK {{ matrix.java }}
-#      # Uses sha for added security since tags can be updated
-#      uses: actions/setup-java@v4
-#      with:
-#        distribution: 'temurin'
-#        java-version: ${{ matrix.java }}
-#        check-latest: true
-#        cache: 'maven'
-#    - name: Download Maven Repo
-#      uses: actions/download-artifact@v4
-#      with:
-#        name: maven-repo
-#        path: .
-#    - name: Extract Maven Repo
-#      shell: bash
-#      run: tar -xzf maven-repo.tgz -C ~
-#    - name: Build with Maven
-#      run: mvn -V -B -am clean verify -Dnative -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }}
+  linux-build-native:
+    name: PR - Linux - Native build - Latest Version
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: validate-format
+    strategy:
+      matrix:
+        java: [ 17, 21 ]
+        image: [ "ubi-quarkus-mandrel-builder-image:jdk-21", "ubi-quarkus-graalvmce-builder-image:jdk-21" ]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install JDK {{ matrix.java }}
+      # Uses sha for added security since tags can be updated
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: ${{ matrix.java }}
+        check-latest: true
+        cache: 'maven'
+    - name: Download Maven Repo
+      uses: actions/download-artifact@v4
+      with:
+        name: maven-repo
+        path: .
+    - name: Extract Maven Repo
+      shell: bash
+      run: tar -xzf maven-repo.tgz -C ~
+    - name: Build with Maven
+      run: mvn -V -B -am clean verify -Dnative -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }}
 

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -21,8 +21,11 @@ jobs:
           java-version: 17
           cache: maven
 
+      - name: Make mvnw executable
+        run: chmod +x mvnw
+
       - name: Debug Maven Version
-        run: mvn --version
+        run: ./mvnw --version
 
       - name: Build the Project
         run: mvn clean install -DskipTests
@@ -31,4 +34,4 @@ jobs:
         uses: advanced-security/maven-dependency-submission-action@v3
         with:
           directory: "."
-          correlator: ${{ github.job }}-quarkus-hivemq-client
+          ignore-maven-wrapper: true

--- a/integration-tests/hivemq-client-smallrye/pom.xml
+++ b/integration-tests/hivemq-client-smallrye/pom.xml
@@ -14,6 +14,7 @@
         <surefire-plugin.version>3.5.2</surefire-plugin.version>
         <hive.testcontainers.version>1.20.6</hive.testcontainers.version>
         <include.tests>**/*IT.java</include.tests>
+        <quarkus.native.native-image-xmx>5g</quarkus.native.native-image-xmx>
     </properties>
 
     <dependencies>
@@ -109,6 +110,7 @@
                             </includes>
                             <systemPropertyVariables>
                                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                <quarkus.native.native-image-xmx>${quarkus.native.native-image-xmx}</quarkus.native.native-image-xmx>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Currently, we are not running native tests in CI due to the following weird error:

```
hreads:
  0x00007f040c000b80 STATUS_IN_NATIVE (ALLOW_SAFEPOINT) "vert.x-acceptor-thread-0" - 0x00007f045bf089e8, stack(0x00007f0436e02000,0x00007f0437e01000)
  0x00007f0414000b80 STATUS_IN_NATIVE (ALLOW_SAFEPOINT) "vert.x-eventloop-thread-2" - 0x00007f04642173c8, stack(0x00007f0441c02000,0x00007f0442c01000)
  0x00007f0418000b80 STATUS_IN_NATIVE (ALLOW_SAFEPOINT) "vert.x-eventloop-thread-3" - 0x00007f0464219a88, stack(0x00007f0440a02000,0x00007f0441a01000)
  0x00007f0424000b80 STATUS_IN_NATIVE (ALLOW_SAFEPOINT) "vert.x-eventloop-thread-0" - 0x00007f0464212660, stack(0x00007f044ca02000,0x00007f044da01000)
  0x00007f041c000b80 STATUS_IN_NATIVE (ALLOW_SAFEPOINT) "vert.x-eventloop-thread-1" - 0x00007f0464214d10, stack(0x00007f0442e02000,0x00007f0443e01000)
  0x00007f042c000b80 STATUS_IN_NATIVE (ALLOW_SAFEPOINT) "executor-thread-0 (scheduler)" - 0x00007f0472d1fe00, daemon, stack(0x00007f044dc02000,0x00007f044ec01000)
  0x00007f0430000b80 STATUS_IN_NATIVE (ALLOW_SAFEPOINT) "pool-10-thread-1" - 0x00007f0467e74da8, stack(0x00007f044ee02000,0x00007f044fe01000)
  0x00007f0438000b80 STATUS_IN_NATIVE (ALLOW_SAFEPOINT) "RxComputationThreadPool-4" - 0x00007f0467e489c0, daemon, stack(0x00007f0458a02000,0x00007f0459a01000)
  0x00007f043c000b80 STATUS_IN_NATIVE (ALLOW_SAFEPOINT) "RxComputationThreadPool-3" - 0x00007f046593dae8, daemon, stack(0x00007f0459c02000,0x00007f045ac01000)
  0x00007f0444000b80 STATUS_IN_NATIVE (ALLOW_SAFEPOINT) "RxComputationThreadPool-2" - 0x00007f0467e381e0, daemon, stack(0x00007f045ae02000,0x00007f045be01000)
  0x00007f0448000b80 STATUS_IN_NATIVE (ALLOW_SAFEPOINT) "RxComputationThreadPool-1" - 0x00007f0465937bc0, daemon, stack(0x00007f0464802000,0x00007f0465801000)
  0x00007f0450000b80 STATUS_IN_NATIVE (ALLOW_SAFEPOINT) "executor-thread-2" - 0x00007f0467e34330, daemon, stack(0x00007f0465a02000,0x00007f0466a01000)
  0x00007f0454000b80 STATUS_IN_JAVA (PREVENT_VM_FROM_REACHING_SAFEPOINT) "com.hivemq.client.mqtt-2-1" - 0x00007f0467e2e770, stack(0x00007f0466c02000,0x00007f0467c01000)
  0x00007f045c000b80 STATUS_IN_NATIVE (ALLOW_SAFEPOINT) "vertx-blocked-thread-checker" - 0x00007f0471a04640, daemon, stack(0x00007f0470802000,0x00007f0471801000)
  ReadOnly References: 0x00007f047bdcd1f8 - 0x00007f047c22fba0
  ReadOnly Relocatables: 0x00007f047c230000 - 0x00007f047c4fba88
  Writable Primitives: 0x00007f047c4fc000 - 0x00007f047c65f7a8
  Writable References: 0x00007f047c65f7a8 - 0x00007f047ccdd340
  Writable Huge: 0x00007f047cd00038 - 0x00007f047cdc3960
  ReadOnly Huge: 0x00007f047cdc4038 - 0x00007f047d654fa8
  
Heap chunks: E=eden, S=survivor, O=old, F=free; A=aligned chunk, U=unaligned chunk; T=to space
  |0x00007f047a500000|0x00007f047a500830, 0x00007f047a542c58, 0x00007f047a580000| 51%|  E|A|
  
Segfault detected, aborting process. Use '-XX:-InstallSegfaultHandler' to disable the segfault handler at run time and create a core dump instead. Rebuild with '-R:-InstallSegfaultHandler' to disable the handler permanently at build time.
```

In my opinion, this issue could be a side effect of insufficient resources. Therefore, in this PR, I am allocating 5GB of RAM for the native test.