### PR TITLE
Switch to using DevServicesConfig

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/hivemqclient/deployment/MqttDevServicesProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/hivemqclient/deployment/MqttDevServicesProcessor.java
@@ -26,7 +26,7 @@ import io.quarkus.deployment.builditem.DockerStatusBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
 import io.quarkus.deployment.console.StartupLogCompressor;
-import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
+import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.deployment.logging.LoggingSetupBuildItem;
 import io.quarkus.devservices.common.ContainerLocator;
 import io.quarkus.runtime.LaunchMode;
@@ -35,7 +35,7 @@ import io.quarkus.runtime.configuration.ConfigUtils;
 /**
  * Starts a HiveMQ broker as dev service if needed.
  */
-@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
 public class MqttDevServicesProcessor {
 
     private static final Logger log = Logger.getLogger(MqttDevServicesProcessor.class);
@@ -59,7 +59,7 @@ public class MqttDevServicesProcessor {
             LaunchModeBuildItem launchMode,
             Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
             LoggingSetupBuildItem loggingSetupBuildItem,
-            GlobalDevServicesConfig devServicesConfig) {
+            DevServicesConfig devServicesConfig) {
 
         MqttDevServiceCfg configuration = getConfiguration();
 
@@ -77,7 +77,7 @@ public class MqttDevServicesProcessor {
                 loggingSetupBuildItem);
         try {
             RunningDevService newDevService = startMqttBroker(dockerStatusBuildItem, configuration, launchMode,
-                    devServicesConfig.timeout);
+                    devServicesConfig.timeout());
             if (newDevService != null) {
                 devService = newDevService;
 


### PR DESCRIPTION
GlobalDevServicesConfig will be dropped in Quarkus 3.26 (we deprecated it in Quarkus 3.19).