### PR TITLE
fix: resolve testcontainers dependency conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ release.properties
 /*/.cache/
 /*/*/.cache/
 .quarkus
+
+# Claude Code
+.claude/settings.local.json

--- a/integration-tests/hivemq-client-smallrye/pom.xml
+++ b/integration-tests/hivemq-client-smallrye/pom.xml
@@ -56,6 +56,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${hive.testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
             <version>${nimbus-jose-jwt.version}</version>


### PR DESCRIPTION
  Add explicit testcontainers dependency to smallrye integration tests
  to resolve version conflict with transitive dependencies. Also add
  Claude Code local settings to .gitignore.