### PR TITLE
ci: fix invalid quarkus-snapshot workflow (duplicate YAML keys)

### DIFF
--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -11,13 +11,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
## Problem

The **Quarkus ecosystem CI** workflow (`.github/workflows/quarkus-snapshot.yaml`) has been failing on every push to `main`, showing up as a red ❌ run that fails immediately (**0s** duration).

Example failing run: `Merge pull request #407 … / .github/workflows/quarkus-snapshot.yaml (push) — 0s — failure`.

## Root cause

The file contains **duplicate top-level keys** — `permissions:` and `concurrency:` each appear twice:

```yaml
permissions:
  contents: read

concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true

permissions:            # <-- duplicate
  contents: read

concurrency:            # <-- duplicate
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

A GitHub Actions workflow file with duplicate top-level keys is **invalid**, so GitHub rejects it and reports the run as failed in 0s.

The duplication was introduced when #405 ("Reuse Ecosystem workflow", `296b146`) was merged together with the "Reduce workflow permissions" change (`ef9dca2`) — both branches added the `permissions:`/`concurrency:` blocks and the merge kept both copies.

## Fix

Remove the duplicated blocks so each key appears exactly once. After the change the top-level keys are unique: `name, on, permissions, concurrency, defaults, jobs`.

## Note (unrelated)

The **Dependabot Updates (maven)** failures visible in the Actions tab (netty / jackson) are a separate issue: they fail with `security_update_dependency_not_found`, which is a Dependabot limitation when a security advisory targets a transitive dependency not directly declared in the `pom`. That is not fixable via this workflow patch and is out of scope here.