### PR TITLE
Release 2.5.1

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: 2.5.0
-  next-version: 2.5.1-SNAPSHOT
+  current-version: 2.5.1
+  next-version: 2.5.2-SNAPSHOT


### PR DESCRIPTION
## Release 2.5.1

Bumps `.github/project.yml` to cut the **2.5.1** release and sets the next development version to `2.5.2-SNAPSHOT`.

```diff
 release:
-  current-version: 2.5.0
-  next-version: 2.5.1-SNAPSHOT
+  current-version: 2.5.1
+  next-version: 2.5.2-SNAPSHOT
```

### How it works
Merging this PR triggers the Quarkiverse **Prepare Release** workflow (`.github/workflows/release-prepare.yml`), which runs on `pull_request: closed` for changes to `.github/project.yml`. That reusable workflow sets the release version in the poms, tags `2.5.1`, and the tag push then triggers **Perform Release** (`release-perform.yml`) to publish to Maven Central.

### Notes
- The current development version was already `2.5.1-SNAPSHOT`, so `2.5.1` is the natural next release.
- CI was previously red because of duplicate YAML keys in `quarkus-snapshot.yaml`; that was fixed in #408 (already merged to `main`), so the workflows are green again before this release.

⚠️ **Merging this PR starts a real release to Maven Central.**