### PR TITLE
docs: update documentation for 2.5.1 release

### DIFF
--- a/docs/modules/ROOT/pages/compatibility.adoc
+++ b/docs/modules/ROOT/pages/compatibility.adoc
@@ -4,6 +4,9 @@ include::./includes/attributes.adoc[]
 
 |===
 | Quarkus-hivemq-client version | Quarkus version | HiveMQ client version
+| 2.5.1
+| 3.30.6
+| 1.3.12
 | 2.5.0
 | 3.26.4
 | 1.3.5

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,5 +1,5 @@
-:quarkus-version: 3.26.4
-:hivemq-mqtt-client: 1.3.3
+:quarkus-version: 3.30.6
+:hivemq-mqtt-client: 1.3.12
 :maven-version: 3.8.1+
 
 :quarkus-org-url: https://github.com/quarkusio


### PR DESCRIPTION
## Documentation update for the 2.5.1 release

Now that **2.5.1** has been released, this updates the docs to reflect it.

### Changes
- **Compatibility matrix** (`compatibility.adoc`): add the `2.5.1` row.

  | Quarkus-hivemq-client | Quarkus | HiveMQ client |
  |---|---|---|
  | 2.5.1 | 3.30.6 | 1.3.12 |

- **Doc attributes** (`includes/attributes.adoc`):
  - `:quarkus-version:` `3.26.4` → `3.30.6` — this feeds the `quarkus:create` quickstart command in `installation.adoc`.
  - `:hivemq-mqtt-client:` `1.3.3` → `1.3.12`.

Versions were taken from the `pom.xml` at the `2.5.1` tag (`quarkus.version=3.30.6`, `hivemq.client.version=1.3.12`).

`docs/antora.yml` is intentionally left at `version: dev` (standard for the development branch).