### PR TITLE
chore(deps): bump Quarkus 3.30.6 → 3.37.1 to pull in patched dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <smallrye-reactive-messaging-mqtt.version>4.30.0</smallrye-reactive-messaging-mqtt.version>
+    <smallrye-reactive-messaging-mqtt.version>4.34.0</smallrye-reactive-messaging-mqtt.version>
     <microprofile-reactive-streams.version>1.0.1</microprofile-reactive-streams.version>
     <microprofile-metrics-api.version>4.0.1</microprofile-metrics-api.version>
     <impsort-maven-plugin.version>1.12.0</impsort-maven-plugin.version>
@@ -39,7 +39,7 @@
     <src.sort.goal>sort</src.sort.goal>
     <checkstyle.version>12.0.1</checkstyle.version>
     <hivemq.client.version>1.3.12</hivemq.client.version>
-    <quarkus.version>3.30.6</quarkus.version>
+    <quarkus.version>3.37.1</quarkus.version>
     <failsafe-plugin.version>3.5.3</failsafe-plugin.version>
     <nimbus-jose-jwt.version>10.6</nimbus-jose-jwt.version>
     <wiremock-standalone.version>3.13.0</wiremock-standalone.version>


### PR DESCRIPTION
## Goal
Reduce the open [Dependabot alerts](https://github.com/quarkiverse/quarkus-hivemq-client/security/dependabot) the **idiomatic way for a Quarkus extension**: stay within the Quarkus BOM (a Quarkus-tested dependency set) instead of overriding individual transitive versions.

> Note: this PR replaces an earlier approach that pinned Netty/Vert.x/OpenTelemetry via `<dependencyManagement>` overrides. We pivoted to a plain Quarkus bump so we don't deviate from the BOM.

## Change
```diff
- <quarkus.version>3.30.6</quarkus.version>
+ <quarkus.version>3.37.1</quarkus.version>
- <smallrye-reactive-messaging-mqtt.version>4.30.0</smallrye-reactive-messaging-mqtt.version>
+ <smallrye-reactive-messaging-mqtt.version>4.34.0</smallrye-reactive-messaging-mqtt.version>
```
Quarkus **3.37.1** is the first release whose BOM already ships the patched dependencies that were flagged:

| Dependency | Before (3.30.6) | After (3.37.1) |
|---|---|---|
| **Netty** (all modules) | 4.1.130.Final | **4.1.135.Final** |
| **vertx-core** (+ stack) | 4.5.23 | **4.5.28** |

`smallrye-reactive-messaging-mqtt` (used only for the `smallrye-connector-attribute-processor` annotation processor) is aligned `4.30.0 → 4.34.0` to match the connector version managed by the 3.37.1 BOM.

No `<dependencyManagement>` overrides are introduced — we stay fully within the Quarkus-tested set.

## Alerts impact
- ✅ **Netty** (~30 alerts) and **vertx-core** fixed by the BOM.
- ✅ Stale alerts (jackson, kafka-clients, commons-lang3, vertx-web, quarkus-*) were already resolved by the current tree; Dependabot will close them on its next scan.
- ⚠️ **One medium remains open: OpenTelemetry.** No Quarkus 3.x BOM ships OTel `1.62.0` yet (3.37.1 has `1.60.1`). It reaches the project transitively via `quarkus-messaging-kafka` in the **integration tests only** (not the published extension) and will close once Quarkus bumps OTel. Deliberately **not** overriding it, to keep zero deviation from the BOM.

## Verification
`./mvnw clean verify` — **BUILD SUCCESS**, all 7 modules, every test passes, including the smallrye integration tests against a real HiveMQ broker (NoAuth / JWT / mTLS / TLS / RBAC) and kitchensink. No functional change.